### PR TITLE
Replaces redirection to confirmation page by modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,8 +244,7 @@ body {
     </div>
     <div class="form-group" id="register_button">
       <button id="eventbrite-widget-modal-trigger-45044537424" class="btn btn-primary" type="button">Pay and Register</button>
-      <small id="inputPronounHelp" class="form-text text-muted">Please disable adblockers if you encouter any difficulties at
-        checkout.<br> You will be redirected to a confirmation page and receive a confirmation email upon successful registration.</small>
+      <small id="inputPronounHelp" class="form-text text-muted">Please disable adblockers if you encouter any difficulties at checkout.</small>
   </div>
     <input type="hidden" name="secret" id="secret" value=""/>
   </form>
@@ -271,7 +270,6 @@ body {
       </div>
     </div>
   </div>
-
 
 <!-- Confirmation Modal -->
     <div class="modal fade" id="confirmationModal" role="dialog">

--- a/index.html
+++ b/index.html
@@ -271,6 +271,26 @@ body {
       </div>
     </div>
   </div>
+
+
+<!-- Confirmation Modal -->
+    <div class="modal fade" id="confirmationModal" role="dialog">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Registration successful</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body" id="confirmation-content">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <footer class="footer">
@@ -295,8 +315,17 @@ body {
 
 // Eventbrite widget support
 var checkoutCallback = function() {
-  
-    $("#main_form").submit();
+
+  // Manually submit form data using Ajax and display confirmation modal
+  $.ajax({
+        type : 'POST',
+        data: $("#main_form").serialize(),
+        url : $("#main_form").attr('action'),
+        success : function(data){
+            $("#confirmation-content").html(data);
+            $("#confirmationModal").modal("show");
+        }
+    });
 };
 
 window.EBWidgets.createWidget({

--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@ body {
     </div>
     <div class="form-group" id="register_button">
       <button id="eventbrite-widget-modal-trigger-45044537424" class="btn btn-primary" type="button">Pay and Register</button>
-      <small id="inputPronounHelp" class="form-text text-muted">Please disable adblockers if you encouter any difficulties at checkout.</small>
+      <small class="form-text text-muted">Please disable adblockers if you encouter any difficulties at checkout.</small>
   </div>
     <input type="hidden" name="secret" id="secret" value=""/>
   </form>

--- a/registration_server.py
+++ b/registration_server.py
@@ -69,7 +69,9 @@ def register():
     participant = Participant(**kwargs)
     db.session.add(participant)
     db.session.commit()
-    return render_template('success.html', data=participant)
+    r = make_response(render_template('success.html', data=participant))
+    r.headers.set('Access-Control-Allow-Origin',"*")
+    return r
 
 @app.route('/', methods=['GET'])
 def registered():

--- a/registration_server.py
+++ b/registration_server.py
@@ -1,6 +1,6 @@
 import os
 import argparse
-from flask import Flask, render_template, request, redirect, url_for, Response
+from flask import Flask, render_template, request, redirect, url_for, Response, make_response
 from functools import wraps
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.sql.sqltypes import Boolean

--- a/templates/success.html
+++ b/templates/success.html
@@ -14,7 +14,7 @@
   <h1>You are going to the DESC meeting !</h1>
   <br>
   <br>
-  We are looking forward to seeing you in Pittsburgh {{data.first_name}}.
+  {{data.first_name}}, we are looking forward to seeing you in Pittsburgh.
   <br>
   Please find travel and hotel information on the meeting <a href="https://confluence.slac.stanford.edu/display/LSSTDESC/CMU+2018+-+Logistics" target="_top">Confluence page</a>.
   <div align="right">


### PR DESCRIPTION
Redirection upon form submission was causing some issues with firefox ( issue #9). This PR replaces the standard submission by a modal that appears in the background showing when registration is successful.