### PR TITLE
U/eiff l/simplify checkout

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@ body {
 .embed-responsive{
     max-height: calc(100vh - 225px);
 }
-/* 
+/*
 #registrationModal .modal-footer {
   justify-content: space-between;
 } */
@@ -389,48 +389,48 @@ document.getElementById("register").onclick = function(e) {
   return false;
 }
 
-// // Validate the form before authorising checkout
-// $(function(){
-//   document.getElementById("register_button").addEventListener("click", function(event) {
-//     var form = document.getElementById("main_form");
-//
-//     // Custom checks
-//     // Check that at least one day is selected
-//     if($("#Attendance :input").filter(':checked').length >= 1){
-//       $.each($("#Attendance :input"), function(index, obj){
-//         obj.setCustomValidity("");
-//       });
-//     }else{
-//       $.each($("#Attendance :input"), function(index, obj){
-//         obj.setCustomValidity("Select at least one day");
-//       });
-//     }
-//
-//
-//     // If form is not validated, don't trigger the registration
-//     if(form.checkValidity() === false){
-//       event.preventDefault();
-//       event.stopPropagation();
-//     }
-//     form.classList.add('was-validated');
-// }, true);
-// });
+// Validate the form before authorising checkout
+$(function(){
+  document.getElementById("register_button").addEventListener("click", function(event) {
+    var form = document.getElementById("main_form");
 
-// // Function to disable the form if the backend is unavailable
-//   var getUrlParameter = function getUrlParameter(sParam) {
-//     var sPageURL = decodeURIComponent(window.location.search.substring(1)),
-//         sURLVariables = sPageURL.split('&'),
-//         sParameterName,
-//         i;
-//
-//     for (i = 0; i < sURLVariables.length; i++) {
-//         sParameterName = sURLVariables[i].split('=');
-//
-//         if (sParameterName[0] === sParam) {
-//             return sParameterName[1] === undefined ? true : sParameterName[1];
-//         }
-//     }
-// };
+    // Custom checks
+    // Check that at least one day is selected
+    if($("#Attendance :input").filter(':checked').length >= 1){
+      $.each($("#Attendance :input"), function(index, obj){
+        obj.setCustomValidity("");
+      });
+    }else{
+      $.each($("#Attendance :input"), function(index, obj){
+        obj.setCustomValidity("Select at least one day");
+      });
+    }
+
+
+    // If form is not validated, don't trigger the registration
+    if(form.checkValidity() === false){
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    form.classList.add('was-validated');
+}, true);
+});
+
+// Function to disable the form if the backend is unavailable
+  var getUrlParameter = function getUrlParameter(sParam) {
+    var sPageURL = decodeURIComponent(window.location.search.substring(1)),
+        sURLVariables = sPageURL.split('&'),
+        sParameterName,
+        i;
+
+    for (i = 0; i < sURLVariables.length; i++) {
+        sParameterName = sURLVariables[i].split('=');
+
+        if (sParameterName[0] === sParam) {
+            return sParameterName[1] === undefined ? true : sParameterName[1];
+        }
+    }
+};
 
 var backend = getUrlParameter('backend');
 var secret  = getUrlParameter('secret');

--- a/index.html
+++ b/index.html
@@ -26,10 +26,10 @@ body {
 .embed-responsive{
     max-height: calc(100vh - 225px);
 }
-
+/* 
 #registrationModal .modal-footer {
   justify-content: space-between;
-}
+} */
 
 #badge span {
   font-family: "Raleway";
@@ -316,10 +316,13 @@ body {
           <div class="embed-responsive embed-responsive-1by1">
             <iframe class="embed-responsive-item" src="https://www.cvent.com/events/lsst-desc-winter-collaboration-meeting/registration-1672e3a8972a4d608897b80dd32f5ce4.aspx?fqp=true" allowfullscreen></iframe>
           </div>
-          <small class="form-text text-muted" align="right">Please make sure to complete the payement process, <u>your registration will not be considered valid otherwise.</u> </small>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-warning" data-dismiss="modal" id="cancelRegistration">Cancel</button>
+          <small class="form-text text-muted" align="right">Please make sure to complete the payement process, <u>your registration will not be considered valid otherwise.</u>
+            <br>
+            Upon successful completion you will receive a confirmation email, please contact the LOC should you encouter any issues with your payment.
+           </small>
+          <!-- <button type="button" class="btn btn-warning" data-dismiss="modal" id="cancelRegistration">Cancel</button>
           <form class="form-inline">
           <div class="form-check">
             <input class="form-check-input" type="checkbox" onchange="document.getElementById('completeRegistration').disabled = !this.checked; document.getElementById('registration_complete').value = true;" value="" id="cventCheck">
@@ -329,7 +332,7 @@ body {
           <div class="form-group">
           <button type="button" class="btn btn-success" data-dismiss="modal" id="completeRegistration" disabled="true" onclick="checkoutCallback()">Finalize Registration</button>
         </div>
-          </form>
+          </form> -->
         </div>
       </div>
     </div>
@@ -386,48 +389,48 @@ document.getElementById("register").onclick = function(e) {
   return false;
 }
 
-// Validate the form before authorising checkout
-$(function(){
-  document.getElementById("register_button").addEventListener("click", function(event) {
-    var form = document.getElementById("main_form");
+// // Validate the form before authorising checkout
+// $(function(){
+//   document.getElementById("register_button").addEventListener("click", function(event) {
+//     var form = document.getElementById("main_form");
+//
+//     // Custom checks
+//     // Check that at least one day is selected
+//     if($("#Attendance :input").filter(':checked').length >= 1){
+//       $.each($("#Attendance :input"), function(index, obj){
+//         obj.setCustomValidity("");
+//       });
+//     }else{
+//       $.each($("#Attendance :input"), function(index, obj){
+//         obj.setCustomValidity("Select at least one day");
+//       });
+//     }
+//
+//
+//     // If form is not validated, don't trigger the registration
+//     if(form.checkValidity() === false){
+//       event.preventDefault();
+//       event.stopPropagation();
+//     }
+//     form.classList.add('was-validated');
+// }, true);
+// });
 
-    // Custom checks
-    // Check that at least one day is selected
-    if($("#Attendance :input").filter(':checked').length >= 1){
-      $.each($("#Attendance :input"), function(index, obj){
-        obj.setCustomValidity("");
-      });
-    }else{
-      $.each($("#Attendance :input"), function(index, obj){
-        obj.setCustomValidity("Select at least one day");
-      });
-    }
-
-
-    // If form is not validated, don't trigger the registration
-    if(form.checkValidity() === false){
-      event.preventDefault();
-      event.stopPropagation();
-    }
-    form.classList.add('was-validated');
-}, true);
-});
-
-// Function to disable the form if the backend is unavailable
-  var getUrlParameter = function getUrlParameter(sParam) {
-    var sPageURL = decodeURIComponent(window.location.search.substring(1)),
-        sURLVariables = sPageURL.split('&'),
-        sParameterName,
-        i;
-
-    for (i = 0; i < sURLVariables.length; i++) {
-        sParameterName = sURLVariables[i].split('=');
-
-        if (sParameterName[0] === sParam) {
-            return sParameterName[1] === undefined ? true : sParameterName[1];
-        }
-    }
-};
+// // Function to disable the form if the backend is unavailable
+//   var getUrlParameter = function getUrlParameter(sParam) {
+//     var sPageURL = decodeURIComponent(window.location.search.substring(1)),
+//         sURLVariables = sPageURL.split('&'),
+//         sParameterName,
+//         i;
+//
+//     for (i = 0; i < sURLVariables.length; i++) {
+//         sParameterName = sURLVariables[i].split('=');
+//
+//         if (sParameterName[0] === sParam) {
+//             return sParameterName[1] === undefined ? true : sParameterName[1];
+//         }
+//     }
+// };
 
 var backend = getUrlParameter('backend');
 var secret  = getUrlParameter('secret');

--- a/registration_server.py
+++ b/registration_server.py
@@ -81,8 +81,8 @@ def register():
 def registered():
     """Returns the list of registered participants
     """
-    # Get list of participants 
-    participants = Participant.query.filter(Participant.registration_complete=='true').with_entities(Participant.first_name,
+    # Get list of participants
+    participants = Participant.query.distinct(Participant.email).with_entities(Participant.first_name,
                                                    Participant.last_name,
                                                    Participant.affiliation).order_by(Participant.last_name).all()
     return render_template('participants.html', data=participants)


### PR DESCRIPTION
Removes buttons in the checkout modal, this way people can't close the modal, they have to go through payment or close the entire page. We abandon the idea of keeping track of successful payment from this form, we'll have to cross-match with the cvent registration list afterwards and go after people who might not have payed manually¯\_(ツ)_/¯
Also change the way the registrant list shows up, removes multiple entries in the database (from possible multiple attempts at registering).