### PR TITLE
Fixes problems with interactions between form and server

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@ body {
         <input class="form-check-input" type="checkbox" id="contact" name="contact">
         <label class="form-check-label" for="contact">
           As described in the <a href="http://lsstdesc.org/sites/default/files/LSST_DESC_Professional_Conduct.pdf#page=11" target="_blank">DESC Meeting Contact Person Policy</a>, Meeting Contact Persons (MCPs) will be available (by Zoom and Slack) to meeting participants and be afforded the authority to take action to resolve disputes, conflicts, or harmful situations.
-MCPs will be selected from eligible participants, and be appointed by the Collaboration Council and the Management Team. All MCP appointments will be confirmed and scheduled with candidates before the meeting. 
+MCPs will be selected from eligible participants, and be appointed by the Collaboration Council and the Management Team. All MCP appointments will be confirmed and scheduled with candidates before the meeting.
           Check if you do NOT wish to be considered for the role of an MCP.
          </label>
        </div>
@@ -283,7 +283,6 @@ MCPs will be selected from eligible participants, and be appointed by the Collab
       <small class="form-text text-muted">Please disable adblockers if you encounter any difficulties with completing the registration.</small>
   </div>
     <input type="hidden" name="secret" id="secret" value=""/>
-    <input type="hidden" name="registration_complete" id="registration_complete" value="false"/>
   </form>
 </div>
 
@@ -363,7 +362,7 @@ MCPs will be selected from eligible participants, and be appointed by the Collab
     </div>
   </div>
 -->
- <!-- </div>  --> 
+ <!-- </div>  -->
 
 <footer class="footer">
     <div class="container">
@@ -385,7 +384,6 @@ MCPs will be selected from eligible participants, and be appointed by the Collab
 
 // Callback to validate registration
 var checkoutCallback = function() {
-
   // Manually submit form data using Ajax and display confirmation modal
   $.ajax({
         type : 'POST',
@@ -401,18 +399,8 @@ var checkoutCallback = function() {
 
 
 document.getElementById("register").onclick = function(e) {
-  //Submit partial registration to the server
-  $.ajax({
-        type : 'POST',
-        data: $("#main_form").serialize(),
-        url : $("#main_form").attr('action')
-    });
+  checkoutCallback()
 
-  /*
-  $('#registrationModal').modal({show: true,
-  keyboard: false,
-  backdrop: 'static'});
-  */
   e.preventDefault();
   return false;
 }
@@ -433,7 +421,6 @@ $(function(){
         obj.setCustomValidity("Select at least one day");
       });
     }
-
 
     // If form is not validated, don't trigger the registration
     if(form.checkValidity() === false){

--- a/registration_server.py
+++ b/registration_server.py
@@ -39,8 +39,6 @@ class Participant(db.Model):
     recording = db.Column(db.String(5))
     code_of_conduct = db.Column(db.String(5))
 
-    registration_complete = db.Column(db.String(5))
-
     def __repr__(self):
         return '<Participant: %r %r [%r]>' % (self.first_name, self.last_name, self.email)
 
@@ -59,8 +57,7 @@ def requires_auth(f):
 def check_email():
     email = request.form['email']
     # Check for already registered email
-    if Participant.query.filter(and_(Participant.email == email,
-                                     Participant.registration_complete=='true')).count() == 0:
+    if Participant.query.filter(Participant.email == email).count() == 0:
         return ("Ok", {'Access-Control-Allow-Origin':'*'})
     else:
         return ("Email already registered", {'Access-Control-Allow-Origin':'*'})

--- a/templates/success.html
+++ b/templates/success.html
@@ -11,10 +11,10 @@
 <body>
 
 <div class="container">
-  <h2>You are going to the DESC meeting !</h2>
+  <h2>You are registered for the DESC meeting !</h2>
   <br>
   <br>
-  {{data.first_name}}, we are looking forward to seeing you in Berkeley.
+  {{data.first_name}}, we are looking forward to seeing at our virtual meeting.
   <br>
   Please check your emails for confirmation of your payment.
   <br>


### PR DESCRIPTION
This small PR removes some messy things we had to accomodate the separate payment process for the last meeting. 

I removed a useless field from the database, so there is a chance this won't work anymore with your already created test database @jiwoncpark :-/ 
To clean the database you might have to delete your current participants table, and execute on the  heorku instance the following command:
```bash
$ python registration_server.py --create
```
Or, maybe simpler, you could delete and re-create a heroku instance. 

With these modifications, now the following should happen:
  - If people have already registered, when they try to add their email address the field should be invalidated, telling them they are already registered
   - When they click on register, if all goes well, they see a pop-up message telling them the process has been successful. 

Note that I also realized that success message may need to be updated ^^':
https://github.com/LSSTDESC/meeting-registration-form/blob/4008a8bbd15c4841a714cdf3834d44a9c5e46204/templates/success.html#L22


