### PR TITLE
U/jiwoncpark/database access

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,16 @@ the following html code (again, replace `SERVER_URL` and `SECRET_KEY`):
    - Click the *Insert* button, go to *Other macros*.
    - Insert and *HTML* macro (not *HTML Include*).
    - Add the above html snippet. Save. Done !
+
+- Step 8 (optional): View the database:
+   - From the Heroku dashboard, once again, click on *Manage App* then *Settings* and finally click the *Reveal Config Vars* button.
+   - Copy the value of `DATABASE_URL`. The database can be viewed and edited using this URL using a postgres server. Whoever creates the Heroku app should share this URL with the Meetings Committee but ensure that it's never publicly accessible.
+   - To read it as a Pandas DataFrame, install `sqlalchemy`, e.g. via `pip3 install sqlalchemy` and run
+
+```python
+import pandas as pd
+from sqlalchemy import create_engine
+engine = create_engine(DATABASE_URL)
+df = pd.read_sql_table('participants', engine) # read as DataFrame
+df.to_csv('participants.csv') # optionally export as a csv file 
+```

--- a/registration_server.py
+++ b/registration_server.py
@@ -99,7 +99,7 @@ def registered():
     """Returns the list of registered participants
     """
     # Get list of participants
-    participants = Participant.query.distinct(Participant.email).order_by(Participant.email, Participant.last_name).with_entities(Participant.first_name,
+    participants = Participant.query.distinct(Participant.email).order_by(Participant.last_name, Participant.first_name).with_entities(Participant.first_name,
                                                    Participant.last_name,
                                                    Participant.affiliation).all()
     return render_template('participants.html', data=participants)

--- a/registration_server.py
+++ b/registration_server.py
@@ -99,9 +99,7 @@ def registered():
     """Returns the list of registered participants
     """
     # Get list of participants
-    participants = Participant.query.distinct(Participant.email).order_by(Participant.last_name, Participant.first_name).with_entities(Participant.first_name,
-                                                   Participant.last_name,
-                                                   Participant.affiliation).all()
+    participants = Participant.query.order_by(Participant.last_name, Participant.first_name).with_entities(Participant.first_name, Participant.last_name, Participant.affiliation).all()
     return render_template('participants.html', data=participants)
 
 if __name__ == '__main__':

--- a/templates/success.html
+++ b/templates/success.html
@@ -14,7 +14,7 @@
   <h2>You are registered for the DESC meeting!</h2>
   <br>
   <br>
-  {{data.first_name}}, we are looking forward to seeing you at our virtual meeting.
+  {{data.first_name}}, we are looking forward to seeing you at our virtual meeting. The <a href="https://confluence.slac.stanford.edu/display/LSSTDESC/DESC+July+2020+Meeting%3A+Participants" target="_blank">Participants tab</a> on the July Meeting confluence page links to a live participant list, where you can confirm your registration.
   <!--<br>
   Please check your emails for confirmation of your registration.
   <br>


### PR DESCRIPTION
I've just added some instructions in the README to address #26 raised by @AlexGKim. The database URL should be kept from public access, so maybe whoever creates the Heroku app for each meeting can share it with the Meetings Committee in the private Slack channel, so the Committee members can view the database at any time.