### PR TITLE
Fix CEST to CET

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,12 +194,12 @@
             discussions, but you expect to be working on sprints mostly outside of the designated timeslots.
           </li>
         </ul>
-        To help accomodate participants from both sides of the Atlantic, we propose two sprinting hubs: one centered on Central European Standard Time, and
+        To help accomodate participants from both sides of the Atlantic, we propose two sprinting hubs: one centered on Central European Time, and
         the other one on Pacific Standard Time.
         <ul>
           <li> <b>American Sprint Time</b>: 8am-2pm PST, or equivalently 11am-5pm EST
           </li>
-          <li> <b>European Sprint Time</b>: 1pm-7pm CEST
+          <li> <b>European Sprint Time</b>: 1pm-7pm CET
           </li>
         </ul>
         These two regional sprint timeslots will overlap each day for 2 hours, allowing for some globally synchronous discussions and events.


### PR DESCRIPTION
As Yao rightly highlighted there is no such thing as Central European Standard Time, this PR just corrects the mentions to the timezones in the text of the form