### PR TITLE
Fix up URL for participants list

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Checkout a preview of the registration form
 - Step 3: Choose a name for your registration server:
  ![alt text](.static/im1.png)
 
-  In this example, the `SERVER_URL` will be `https://desc-july2021-meeting.herokuapp.com/`
+  In this example, the `SERVER_URL` will be `https://desc-summer-meeting.herokuapp.com/`
 
 - Step 4: Click the *Deploy* button and let the magic happen.
 

--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@
       <dl class="row">
         <span class="text-muted">
           <p class="lead">Privacy notice</p>
-          <p>Your <mark>first name, last name, and affiliation will appear on a public <a href="https://jrb-desc-july2021.herokuapp.com" target="_blank"> webpage </a> </mark> linked in the meeting's confluence participants page. Your email will be used to contact you when necessary. All data collected here may be shared with LSST DESC
+          <p>Your <mark>first name, last name, and affiliation will appear on a public <a href="https://desc-july2021-meeting.herokuapp.com" target="_blank"> webpage </a> </mark> linked in the meeting's confluence participants page. Your email will be used to contact you when necessary. All data collected here may be shared with LSST DESC
             members who are on the Logistics Organizing Committee (LOC), the Scientific Organizing Committee (SOC), the Meetings Committee, the Collaboration Council, and the Management Team.
           </p>
       </dl>


### PR DESCRIPTION
Fix information URL in privacy notice.
Cosmetic change to README, so text matches image