### PR TITLE
Minor fix of the success URL for production version

### DIFF
--- a/templates/payment.html
+++ b/templates/payment.html
@@ -29,7 +29,7 @@
       <input type="hidden" name="pmt_type" maxlength="3" value="201" />
       <input type="hidden" name="account" maxlength="15" value="desc-form" />
       <input type="hidden" name="finish_url" maxlength="60"
-        value="https://desc-meeting-august22-dev.herokuapp.com/ok" />
+        value="https://desc-aug22-meeting.herokuapp.com/ok" />
       <input type="hidden" name="cancel_url" maxlength="60" value="" />
       <input type="hidden" name="consumer_firstname" maxlength="20" value="{{data.first_name}}" />
       <input type="hidden" name="consumer_lastname" maxlength="50" value="{{data.last_name}}" />


### PR DESCRIPTION
This small fix corrects the link of the success URL to the production version. I'm opening an issue to keep track of the need to replace this hardcoded thing. But it's possible that we won't need this functionality again, this was specific for the chicago payment system. 