### PR TITLE
Implements a few fixes to support Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -720,14 +720,17 @@
       $('#in_person').click(function () {
         $('#in_person_info').toggle(500);
 
-        if ($('#in_person').clicked == True) {
-          $('#pronoun').required = true;
-          $('#covid_vaccine').required = true;
-          $('#covid_rules').required = true;
+        if (document.getElementById("in_person").checked) {
+          document.getElementById("pronoun").required = true;
+          document.getElementById("covid_vaccine").required = true;
+          document.getElementById("covid_rules").required = true;
+
+
         } else {
-          $('#pronoun').required = false;
-          $('#covid_vaccine').required = false;
-          $('#covid_rules').required = false;
+          document.getElementById("pronoun").required = false;
+          document.getElementById("covid_vaccine").required = false;
+          document.getElementById("covid_rules").required = false;
+
         };
 
       });

--- a/templates/payment.html
+++ b/templates/payment.html
@@ -29,7 +29,7 @@
       <input type="hidden" name="pmt_type" maxlength="3" value="201" />
       <input type="hidden" name="account" maxlength="15" value="desc-form" />
       <input type="hidden" name="finish_url" maxlength="60"
-        value="https://desc-meeting-august22-dev.herokuapp.com/ok" />
+        value="https://desc-aug22-meeting.herokuapp.com/ok" />
       <input type="hidden" name="cancel_url" maxlength="60" value="" />
       <input type="hidden" name="consumer_firstname" maxlength="20" value="{{data.first_name}}" />
       <input type="hidden" name="consumer_lastname" maxlength="50" value="{{data.last_name}}" />

--- a/templates/payment.html
+++ b/templates/payment.html
@@ -59,7 +59,7 @@
           </div>
         </div>
         <div class="col-auto">
-          <button type="submit" class="btn btn-primary mb-2" onclick="disableForm()">Pay and Complete
+          <button type="submit" class="btn btn-primary mb-2">Pay and Complete
             Registration</button>
         </div>
       </div>
@@ -77,12 +77,6 @@
     } else {
       document.getElementById("inlineFormInputGroup").value = document.getElementById("cost").value;
     }
-  };
-
-  function disableForm(e) {
-    $("#payment_form").submit();
-    // To prevent double payment
-    $("#payment_form :input").prop('disabled', true);
   };
 </script>
 


### PR DESCRIPTION
This small PR changes a little bit the form submission behavior to be compatible with Firefox

The issue was that the form was submitted after the inputs were disabled (which was intended to be safeguard to prevent people for submitting the form multiple times, but which actually not needed as long as we don't open the payment site in a new tab.) Chrome and Firefox had different behavior there.