### PR TITLE
Adds a column to show participation type 

### DIFF
--- a/registration_server.py
+++ b/registration_server.py
@@ -121,7 +121,7 @@ def registered():
     """
     # Get list of participants
     participants = Participant.query.order_by(Participant.last_name, Participant.first_name).with_entities(
-        Participant.first_name, Participant.last_name, Participant.affiliation).all()
+        Participant.first_name, Participant.last_name, Participant.affiliation, Participant.in_person).all()
     return render_template('participants.html', data=participants)
 
 

--- a/templates/participants.html
+++ b/templates/participants.html
@@ -21,6 +21,7 @@
           <th scope="col">First Name</th>
           <th scope="col">Last Name</th>
           <th scope="col">Affiliation</th>
+          <th scope="col">Attendance</th>
         </tr>
       </thead>
       <tbody>
@@ -29,6 +30,7 @@
           <td>{{item.first_name}}</td>
           <td>{{item.last_name}}</td>
           <td>{{item.affiliation}}</td>
+          <td>{% if item.in_person == "on"%}In Person{% else %}Remote{% endif %}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/payment_success.html
+++ b/templates/payment_success.html
@@ -17,7 +17,7 @@
 
         <div class="alert alert-info" role="alert">
             You should have received by email a confirmation of your payment from <i>maureenlowery@uchicago.edu</i>,
-            with a receipt mentioning <i>SUM 2022 LSST DESC MTG</i>. If you have any questions
+            with a receipt mentioning <i>SUM 2022 LSST DESC MTG</i> (<b>please ignore any reference to "CMB Pol Workshop"</b>). If you have any questions
             regarding payment, please reach out to the LOC or ask on <a href="https://lsstc.slack.com/archives/C0176US657B">#desc-collab-meeting-hotline</a>.
         </div>
 

--- a/templates/payment_success.html
+++ b/templates/payment_success.html
@@ -17,7 +17,7 @@
 
         <div class="alert alert-info" role="alert">
             You should have received by email a confirmation of your payment from <i>maureenlowery@uchicago.edu</i>,
-            with a receipt mentioning <i>SUM 2022 LSST DESC MTG</i> (<b>please ignore any reference to "CMB Pol Workshop"</b>). If you have any questions
+            with a receipt mentioning <i>SUM 2022 LSST DESC MTG</i>. If you have any questions
             regarding payment, please reach out to the LOC or ask on <a href="https://lsstc.slack.com/archives/C0176US657B">#desc-collab-meeting-hotline</a>.
         </div>
 


### PR DESCRIPTION
This adds a test column on the participants page, showing either "In Person" or "Remote" participation type:
![image](https://user-images.githubusercontent.com/861591/171950937-43420577-804b-4a35-b53f-3877cba947de.png)
